### PR TITLE
Autogenerate hash

### DIFF
--- a/buildSrc/src/main/kotlin/rt.gradle.kts
+++ b/buildSrc/src/main/kotlin/rt.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
 
     implementation("org.springframework.kafka:spring-kafka:2.7.0")
     implementation("org.springframework.kafka:spring-kafka-test:2.7.0")
+    implementation("commons-codec:commons-codec:1.15")
 
     testImplementation("io.mockk:mockk:${mockkVersion}")
     testImplementation(kotlin("test-junit5"))

--- a/messaging-service/src/main/kotlin/com/forge/messageservice/authentication/UserContext.kt
+++ b/messaging-service/src/main/kotlin/com/forge/messageservice/authentication/UserContext.kt
@@ -21,7 +21,11 @@ object UserContext {
         return JwtUser("SYSTEM", "SYSTEM", Date.from(Instant.now()), listOf())
     }
 
-    fun loggedInUsername() = loggedInUser().username
+    fun loggedInUsername(): String = try {
+        loggedInUser().username
+    } catch (e: Exception) {
+        apiClient().applicationCode
+    }
 
     fun apiClient(): JwtApiClient {
         val auth = SecurityContextHolder.getContext().authentication

--- a/messaging-service/src/main/kotlin/com/forge/messageservice/authentication/UserContext.kt
+++ b/messaging-service/src/main/kotlin/com/forge/messageservice/authentication/UserContext.kt
@@ -1,5 +1,6 @@
 package com.forge.messageservice.authentication
 
+import com.forge.messageservice.authentication.jwt.JwtApiClient
 import com.forge.messageservice.authentication.jwt.JwtUser
 import org.springframework.security.core.context.SecurityContextHolder
 import java.time.Instant
@@ -7,11 +8,31 @@ import java.util.*
 
 object UserContext {
 
-    fun loggedInUser(): JwtUser{
-        if (SecurityContextHolder.getContext().authentication != null)
-            return SecurityContextHolder.getContext().authentication.principal as JwtUser
+    fun loggedInUser(): JwtUser {
+        val auth = SecurityContextHolder.getContext().authentication
+        if (auth != null) {
+            if (auth.principal is JwtUser) {
+                return SecurityContextHolder.getContext().authentication.principal as JwtUser
+            }
+
+            throw Exception("Trying to obtain JwtUser but auth principal is ${auth.principal.javaClass.name}")
+        }
+
         return JwtUser("SYSTEM", "SYSTEM", Date.from(Instant.now()), listOf())
     }
 
     fun loggedInUsername() = loggedInUser().username
+
+    fun apiClient(): JwtApiClient {
+        val auth = SecurityContextHolder.getContext().authentication
+        if (auth != null) {
+            if (auth.principal is JwtApiClient) {
+                return SecurityContextHolder.getContext().authentication.principal as JwtApiClient
+            }
+
+            throw Exception("Trying to obtain APIClient but auth principal is ${auth.principal.javaClass.name}")
+        }
+
+        throw Exception("No authenticated API Client is found in the SecurityContext")
+    }
 }

--- a/messaging-service/src/main/kotlin/com/forge/messageservice/authentication/jwt/JwtApiClient.kt
+++ b/messaging-service/src/main/kotlin/com/forge/messageservice/authentication/jwt/JwtApiClient.kt
@@ -1,0 +1,9 @@
+package com.forge.messageservice.authentication.jwt
+
+import java.util.*
+
+data class JwtApiClient(
+    val applicationCode: String,
+    val name: String,
+    val dateIssued: Date
+)

--- a/messaging-service/src/main/kotlin/com/forge/messageservice/authentication/jwt/JwtToSpringAuthenticationBuilder.kt
+++ b/messaging-service/src/main/kotlin/com/forge/messageservice/authentication/jwt/JwtToSpringAuthenticationBuilder.kt
@@ -1,0 +1,49 @@
+package com.forge.messageservice.authentication.jwt
+
+import com.forge.messageservice.services.LdapUserService
+import io.jsonwebtoken.Claims
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.Authentication
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource
+import javax.servlet.http.HttpServletRequest
+
+internal class JwtToSpringAuthenticationBuilder(
+    private val ldapUserService: LdapUserService,
+    private val jwtTokenProvider: JwtTokenProvider
+) {
+
+    private lateinit var tokenHolder: TokenHolder
+    private lateinit var request: HttpServletRequest
+
+    fun withToken(tokenHolder: TokenHolder): JwtToSpringAuthenticationBuilder {
+        this.tokenHolder = tokenHolder
+        return this
+    }
+
+    fun withHttpServletRequest(request: HttpServletRequest): JwtToSpringAuthenticationBuilder {
+        this.request = request
+        return this
+    }
+
+    fun build(): Authentication {
+        val claims = jwtTokenProvider.getClaims(tokenHolder.token)
+
+        val username = claims.subject
+        val roles = claims["roles"] as List<String>
+        val authorities = roles.map { role -> SimpleGrantedAuthority(role) }
+        val userDetails = createAuthDetailsFor(username, claims)
+
+        val authentication = UsernamePasswordAuthenticationToken(userDetails, null, authorities)
+        authentication.details = WebAuthenticationDetailsSource().buildDetails(request)
+
+        return authentication
+    }
+
+    private fun createAuthDetailsFor(username: String, claims: Claims): Any {
+        return when (tokenHolder.tokenType) {
+            TokenType.USER -> JwtUser(username, ldapUserService.getNameOfUser(username), claims.issuedAt, emptyList())
+            TokenType.API_CLIENT -> JwtApiClient(username, username, claims.issuedAt)
+        }
+    }
+}

--- a/messaging-service/src/main/kotlin/com/forge/messageservice/authentication/jwt/JwtTokenAuthenticationFilter.kt
+++ b/messaging-service/src/main/kotlin/com/forge/messageservice/authentication/jwt/JwtTokenAuthenticationFilter.kt
@@ -4,17 +4,12 @@ import com.forge.messageservice.authentication.UserContext
 import com.forge.messageservice.controllers.exceptions.APIKeyNotFoundException
 import com.forge.messageservice.repositories.ApiClientRepository
 import com.forge.messageservice.services.LdapUserService
-import io.jsonwebtoken.Claims
 import io.jsonwebtoken.ExpiredJwtException
 import io.jsonwebtoken.MalformedJwtException
 import io.jsonwebtoken.UnsupportedJwtException
 import org.slf4j.MDC
 import org.springframework.http.HttpHeaders.AUTHORIZATION
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
-import org.springframework.security.core.Authentication
-import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.core.context.SecurityContextHolder
-import org.springframework.security.web.authentication.WebAuthenticationDetailsSource
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher
 import org.springframework.security.web.util.matcher.RequestMatcher
 import org.springframework.web.filter.OncePerRequestFilter
@@ -22,43 +17,42 @@ import java.text.ParseException
 import javax.servlet.FilterChain
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
-import kotlin.jvm.Throws
 
-class JwtTokenAuthenticationFilter (
+class JwtTokenAuthenticationFilter(
     private val jwtTokenProvider: JwtTokenProvider,
     private val apiClientRepository: ApiClientRepository,
     private val ldapUserService: LdapUserService,
     path: String
-): OncePerRequestFilter(){
+) : OncePerRequestFilter() {
     companion object {
         private const val API_TOKEN_HEADER = "x-api-key"
     }
+
     private val requestMatcher: RequestMatcher
 
-
-    override fun doFilterInternal(request: HttpServletRequest, response: HttpServletResponse, filterChain: FilterChain) {
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain
+    ) {
         try {
-            if(hasNoAuthorization(request)){
-                filterChain.doFilter(request,response)
+            if (hasNoAuthorization(request)) {
+                filterChain.doFilter(request, response)
                 return
             }
-            val token: String
-            if (hasAuthHeader(request, API_TOKEN_HEADER)){
-                token = extractAndDecodeJwtTokenForm(request, API_TOKEN_HEADER)
-                if (!apiClientRepository.existsByAccessKey(token)){
-                    throw APIKeyNotFoundException("API Key $token has expired or has yet to be registered")
-                }
-            } else {
-                token = extractAndDecodeJwtTokenForm(request, AUTHORIZATION)
-            }
-            checkAuthenticationAndValidity(token)
 
-            val claims = jwtTokenProvider.getClaims(token)
-            val auth = buildAuthenticationFromJwt(claims, request)
+            val token = getTokenFrom(request)
+            checkAuthenticationAndValidity(token.token)
+
+            val auth = JwtToSpringAuthenticationBuilder(ldapUserService, jwtTokenProvider)
+                .withToken(token)
+                .withHttpServletRequest(request)
+                .build()
+
             SecurityContextHolder.getContext().authentication = auth
             MDC.put("username", UserContext.loggedInUsername())
             filterChain.doFilter(request, response)
-        } catch (e: Exception){
+        } catch (e: Exception) {
             handleException(e, response)
         } finally {
             SecurityContextHolder.clearContext()
@@ -67,15 +61,31 @@ class JwtTokenAuthenticationFilter (
 
     override fun shouldNotFilter(request: HttpServletRequest) = requestMatcher.matches(request)
 
+    private fun getTokenFrom(request: HttpServletRequest): TokenHolder {
+        return if (hasAuthHeader(request, API_TOKEN_HEADER)) {
+
+            val token = extractAndDecodeJwtTokenForm(request, API_TOKEN_HEADER)
+            if (!apiClientRepository.existsByAccessKey(token)) {
+                throw APIKeyNotFoundException("API Key $token has expired or has yet to be registered")
+            }
+
+            TokenHolder(TokenType.API_CLIENT, token)
+        } else {
+            val token = extractAndDecodeJwtTokenForm(request, AUTHORIZATION)
+            TokenHolder(TokenType.USER, token)
+        }
+    }
+
     @Throws(ParseException::class)
-    private fun extractAndDecodeJwtTokenForm(request: HttpServletRequest, headerKey: String): String{
+    private fun extractAndDecodeJwtTokenForm(request: HttpServletRequest, headerKey: String): String {
         val authHeader = request.getHeader(headerKey)
         return authHeader.substring("Bearer".length)
     }
 
     private fun checkAuthenticationAndValidity(token: String) = jwtTokenProvider.validateToken(token)
 
-    private fun hasNoAuthorization(request: HttpServletRequest) = !(hasAuthHeader(request, AUTHORIZATION) || hasAuthHeader(request, API_TOKEN_HEADER))
+    private fun hasNoAuthorization(request: HttpServletRequest) =
+        !(hasAuthHeader(request, AUTHORIZATION) || hasAuthHeader(request, API_TOKEN_HEADER))
 
     private fun hasAuthHeader(request: HttpServletRequest, headerKey: String): Boolean {
         val header = request.getHeader(headerKey)
@@ -85,23 +95,17 @@ class JwtTokenAuthenticationFilter (
     private fun handleException(e: Exception, response: HttpServletResponse) {
         when (e) {
             is ExpiredJwtException -> response.sendError(HttpServletResponse.SC_FORBIDDEN, "Token is not valid anymore")
-            is UnsupportedJwtException -> response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unsupported JWT Token")
+            is UnsupportedJwtException -> response.sendError(
+                HttpServletResponse.SC_UNAUTHORIZED,
+                "Unsupported JWT Token"
+            )
             is MalformedJwtException -> response.sendError(HttpServletResponse.SC_FORBIDDEN, "Token is malformed")
             else -> throw e
         }
     }
 
-    @Throws(ParseException::class)
-    private fun buildAuthenticationFromJwt(claims: Claims, request: HttpServletRequest): Authentication{
-        val username = claims.subject
-        val roles = claims["roles"] as List<String>
-        val authorities = roles.map { role -> SimpleGrantedAuthority(role) }
-        val userDetails = JwtUser(username, ldapUserService.getNameOfUser(username), claims.issuedAt, listOf())
-        val authentication = UsernamePasswordAuthenticationToken(userDetails, null, authorities)
-        authentication.details = WebAuthenticationDetailsSource().buildDetails(request)
-        return authentication
+    init {
+        requestMatcher = AntPathRequestMatcher(path)
     }
-
-    init { requestMatcher = AntPathRequestMatcher(path) }
 
 }

--- a/messaging-service/src/main/kotlin/com/forge/messageservice/authentication/jwt/TokenHolder.kt
+++ b/messaging-service/src/main/kotlin/com/forge/messageservice/authentication/jwt/TokenHolder.kt
@@ -1,0 +1,10 @@
+package com.forge.messageservice.authentication.jwt
+
+enum class TokenType {
+    USER, API_CLIENT
+}
+
+data class TokenHolder(
+    val tokenType: TokenType,
+    val token: String
+)

--- a/messaging-service/src/main/kotlin/com/forge/messageservice/common/messaging/NotificationTask.kt
+++ b/messaging-service/src/main/kotlin/com/forge/messageservice/common/messaging/NotificationTask.kt
@@ -5,5 +5,6 @@ import java.io.Serializable
 
 data class NotificationTask(
     val channel: Template.AlertType,
+    val subject: String,
     val message: NotificationMessage
 ) : Serializable

--- a/messaging-service/src/main/kotlin/com/forge/messageservice/common/messaging/SendMessageRequest.kt
+++ b/messaging-service/src/main/kotlin/com/forge/messageservice/common/messaging/SendMessageRequest.kt
@@ -1,0 +1,12 @@
+package com.forge.messageservice.common.messaging
+
+import java.util.*
+
+data class SendMessageRequest(
+    val sendersAppCode: String,
+    val templateUUID: UUID,
+    val templateVersionId: Long,
+    val recipients: Recipients,
+    val messageParams: Map<String, Any>,
+    val subject: String?
+)

--- a/messaging-service/src/main/kotlin/com/forge/messageservice/controllers/v1/MessageDispatcherController.kt
+++ b/messaging-service/src/main/kotlin/com/forge/messageservice/controllers/v1/MessageDispatcherController.kt
@@ -1,14 +1,13 @@
 package com.forge.messageservice.controllers.v1
 
-import com.forge.messageservice.common.messaging.NotificationMessage
-import com.forge.messageservice.common.messaging.NotificationTask
-import com.forge.messageservice.common.messaging.Recipients
+import com.forge.messageservice.authentication.UserContext
+import com.forge.messageservice.common.messaging.SendMessageRequest
 import com.forge.messageservice.controllers.v1.api.request.MessageDispatchRequest
-import com.forge.messageservice.entities.Template
 import com.forge.messageservice.services.MessageDispatcherService
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import org.springframework.web.multipart.MultipartFile
+import java.util.*
 
 /**
  * This controller handles incoming messages from clients. Messages received by this controller
@@ -28,27 +27,32 @@ class MessageDispatcherController(
      *
      * This implementation is largely inspired by Python's Celery
      *
+     * Usage:
+     * /v1/messages/{templateUUID}/{templateVersionId}
+     *
+     * Example:
+     * /v1/messages/50c3a8c0-15a0-4ac5-800e-a66f7fb287f7/1
+     *
+     * @param templateUUID Identifies the family of template versions to be used
      * @param templateVersionId Identifies the [TemplateVersion](com.forge.messageservice.entities.TemplateVersion) to be used
-     * @param messageParameter The parameter map to be used to replace placeholders in the template
+     * @param messageDispatchRequest Contains the request details e.g. parameter map, recipients, etc
      */
-    @PostMapping("/{templateVersionId}")
+    @PostMapping("/{templateUUID}/{templateVersionId}")
     fun sendAsync(
-        @PathVariable templateVersionId: String,
+        @PathVariable templateUUID: String,
+        @PathVariable templateVersionId: Long,
         @RequestBody messageDispatchRequest: MessageDispatchRequest,
         @RequestPart("attachments", required = false) attachments: Array<MultipartFile>?
     ): ResponseEntity<String> {
 
-
-
         messageDispatcher.enqueueMessage(
-            NotificationTask(
-                channel = Template.AlertType.EMAIL,
-                message = NotificationMessage(
-                    recipients = Recipients(
-                        to = listOf("")
-                    ),
-                    messageBody = "Hello World"
-                )
+            SendMessageRequest(
+                sendersAppCode = UserContext.apiClient().applicationCode,
+                templateUUID = UUID.fromString(templateUUID),
+                templateVersionId = templateVersionId,
+                recipients = messageDispatchRequest.recipients,
+                messageParams = messageDispatchRequest.parameters,
+                subject = messageDispatchRequest.subject
             )
         )
         return ResponseEntity.ok("ok")

--- a/messaging-service/src/main/kotlin/com/forge/messageservice/controllers/v1/MessageDispatcherController.kt
+++ b/messaging-service/src/main/kotlin/com/forge/messageservice/controllers/v1/MessageDispatcherController.kt
@@ -1,6 +1,10 @@
 package com.forge.messageservice.controllers.v1
 
+import com.forge.messageservice.common.messaging.NotificationMessage
+import com.forge.messageservice.common.messaging.NotificationTask
+import com.forge.messageservice.common.messaging.Recipients
 import com.forge.messageservice.controllers.v1.api.request.MessageDispatchRequest
+import com.forge.messageservice.entities.Template
 import com.forge.messageservice.services.MessageDispatcherService
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
@@ -33,8 +37,22 @@ class MessageDispatcherController(
         @RequestBody messageDispatchRequest: MessageDispatchRequest,
         @RequestPart("attachments", required = false) attachments: Array<MultipartFile>?
     ): ResponseEntity<String> {
-        messageDispatcher.enqueueMessage()
+
+
+
+        messageDispatcher.enqueueMessage(
+            NotificationTask(
+                channel = Template.AlertType.EMAIL,
+                message = NotificationMessage(
+                    recipients = Recipients(
+                        to = listOf("")
+                    ),
+                    messageBody = "Hello World"
+                )
+            )
+        )
         return ResponseEntity.ok("ok")
     }
+
 
 }

--- a/messaging-service/src/main/kotlin/com/forge/messageservice/controllers/v1/api/request/MessageDispatchRequest.kt
+++ b/messaging-service/src/main/kotlin/com/forge/messageservice/controllers/v1/api/request/MessageDispatchRequest.kt
@@ -4,6 +4,6 @@ import com.forge.messageservice.common.messaging.Recipients
 
 data class MessageDispatchRequest(
     val recipients: Recipients,
-    val subject: String,
+    val subject: String?,
     val parameters: Map<String, Any>
 )

--- a/messaging-service/src/main/kotlin/com/forge/messageservice/entities/Template.kt
+++ b/messaging-service/src/main/kotlin/com/forge/messageservice/entities/Template.kt
@@ -8,9 +8,6 @@ import javax.persistence.*
 @Table(name = "templates")
 class Template : Auditable() {
 
-    /**
-     * Auto generated sequence.
-     */
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "template_id")

--- a/messaging-service/src/main/kotlin/com/forge/messageservice/entities/TemplateVersion.kt
+++ b/messaging-service/src/main/kotlin/com/forge/messageservice/entities/TemplateVersion.kt
@@ -23,6 +23,10 @@ class TemplateVersion : Auditable() {
     @Column(name = "template_id")
     var templateId: Long? = null
 
+    @ManyToOne
+    @JoinColumn(name = "template_id", insertable = false, updatable = false)
+    var template: Template? = null
+
     /**
      * A JSON encoded field containing the configuration for the given alert. For emails typical settings may be as follows:
      * ```
@@ -49,15 +53,15 @@ class TemplateVersion : Auditable() {
 
     /**
      * Since the field `version` can be used for optimistic locking and to identify this entity's version, we use
-     * templateHash here instead.
+     * templateDigest here instead.
      *
-     * `TemplateHash` is the SHA256 of the template body.
+     * `templateDigest` is the SHA256 of the template body + settings.
      */
-    @Column(name = "template_hash", nullable = false)
-    var templateHash: String? = null
+    @Column(name = "template_digest", nullable = false)
+    var templateDigest: String? = null
         private set
         get() {
-            generateHashWhenHashIsEmpty()
+            generateTemplateVersionDigestWhenEmpty()
             return field
         }
 
@@ -82,18 +86,14 @@ class TemplateVersion : Auditable() {
     @Column(name = "template_status", length = 24, nullable = false)
     var status: TemplateStatus = TemplateStatus.DRAFT
 
-    @ManyToOne
-    @JoinColumn(name = "template_id", insertable = false, updatable = false)
-    var template: Template? = null
-
     @Transient
     var isDirty: Boolean = false
 
     @PrePersist
     @PreUpdate
-    fun generateHashWhenHashIsEmpty(){
+    fun generateTemplateVersionDigestWhenEmpty(){
         if (isDirty) {
-            this.templateHash = DigestUtils.sha256Hex(settings + body)
+            this.templateDigest = DigestUtils.sha256Hex(settings + body)
         }
     }
 }

--- a/messaging-service/src/main/kotlin/com/forge/messageservice/graphql/models/inputs/MessageInput.kt
+++ b/messaging-service/src/main/kotlin/com/forge/messageservice/graphql/models/inputs/MessageInput.kt
@@ -9,7 +9,8 @@ import javax.validation.constraints.NotNull
 data class MessageInput(
     @NotBlank
     val templateUUID: String,
-    val templateHash: Int,
+    val templateDigest: String,
+
     @NotBlank
     val content: String,
     @NotBlank

--- a/messaging-service/src/main/kotlin/com/forge/messageservice/graphql/models/inputs/PaginationInput.kt
+++ b/messaging-service/src/main/kotlin/com/forge/messageservice/graphql/models/inputs/PaginationInput.kt
@@ -3,19 +3,12 @@ package com.forge.messageservice.graphql.models.inputs
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Sort
 
-class PaginationInput {
-
-    var pageNumber: Int = 1
-    var rowPerPage: Int = 20
-    var sortDirection: Sort.Direction = Sort.Direction.ASC
-    var sortField: String? = null
-
-    constructor(pageNumber: Int, rowPerPage: Int, sortDirection: Sort.Direction, sortField: String?) {
-        this.pageNumber = pageNumber
-        this.rowPerPage = rowPerPage
-        this.sortDirection = sortDirection
-        this.sortField = sortField
-    }
+class PaginationInput(
+    var pageNumber: Int,
+    var rowPerPage: Int,
+    var sortDirection: Sort.Direction,
+    var sortField: String?
+) {
 
     fun asPageRequest(): PageRequest = PageRequest.of(
         pageNumber, rowPerPage, sortDirection, sortField

--- a/messaging-service/src/main/kotlin/com/forge/messageservice/repositories/TemplateVersionRepository.kt
+++ b/messaging-service/src/main/kotlin/com/forge/messageservice/repositories/TemplateVersionRepository.kt
@@ -8,10 +8,15 @@ import org.springframework.stereotype.Repository
 
 @Repository
 interface TemplateVersionRepository : JpaRepository<TemplateVersion, Long> {
+
     fun findAllByTemplateId(templateId: Long): List<TemplateVersion>
+
     fun findByTemplateIdAndStatus(templateId: Long, status: TemplateStatus): TemplateVersion?
+
     fun findByTemplateHashAndTemplateId(templateHash: Int, templateId: Long): TemplateVersion?
+
     @Query("SELECT MAX(t.version) FROM TemplateVersion t where t.templateId = :templateId")
     fun findCurrentVersionNumberByTemplateId(templateId: Long): Long
-    fun existsByTemplateIdAndTemplateHash(templateId: Long, templateHash: Int): Boolean
+
+    fun existsByTemplateIdAndTemplateHash(templateId: Long, templateHash: String): Boolean
 }

--- a/messaging-service/src/main/kotlin/com/forge/messageservice/repositories/TemplateVersionRepository.kt
+++ b/messaging-service/src/main/kotlin/com/forge/messageservice/repositories/TemplateVersionRepository.kt
@@ -13,10 +13,10 @@ interface TemplateVersionRepository : JpaRepository<TemplateVersion, Long> {
 
     fun findByTemplateIdAndStatus(templateId: Long, status: TemplateStatus): TemplateVersion?
 
-    fun findByTemplateHashAndTemplateId(templateHash: Int, templateId: Long): TemplateVersion?
+    fun findByTemplateDigestAndTemplateId(templateDigest: String, templateId: Long): TemplateVersion?
 
     @Query("SELECT MAX(t.version) FROM TemplateVersion t where t.templateId = :templateId")
     fun findCurrentVersionNumberByTemplateId(templateId: Long): Long
 
-    fun existsByTemplateIdAndTemplateHash(templateId: Long, templateHash: String): Boolean
+    fun existsByTemplateIdAndTemplateDigest(templateId: Long, templateDigest: String): Boolean
 }

--- a/messaging-service/src/main/kotlin/com/forge/messageservice/resolvers/queries/TemplateResolver.kt
+++ b/messaging-service/src/main/kotlin/com/forge/messageservice/resolvers/queries/TemplateResolver.kt
@@ -23,7 +23,7 @@ class TemplateResolver(
     }
 
     fun templateVersion(templateVersionId: Long): TemplateVersion {
-        return templateVersionService.getTemplateVersionById(templateVersionId)
+        return templateVersionService.getTemplateVersion(templateVersionId)
     }
 
     fun templates(name: String, appCodes: List<String>, pageRequestInput: PaginationInput): Connection<Template> {

--- a/messaging-service/src/main/kotlin/com/forge/messageservice/resolvers/queries/TemplateVersionResolver.kt
+++ b/messaging-service/src/main/kotlin/com/forge/messageservice/resolvers/queries/TemplateVersionResolver.kt
@@ -21,7 +21,7 @@ class TemplateVersionResolver(
     fun templateVersions(template: Template?): CompletableFuture<List<TemplateVersion>>? {
         return CompletableFuture.supplyAsync(
             Supplier {
-                templateVersionService.getAllTemplateVersionsByTemplateId(template!!.id!!)
+                templateVersionService.getAllTemplateVersionsOf(template!!.id!!)
             },
             executorService
         )

--- a/messaging-service/src/main/kotlin/com/forge/messageservice/services/MessageDispatcherService.kt
+++ b/messaging-service/src/main/kotlin/com/forge/messageservice/services/MessageDispatcherService.kt
@@ -23,18 +23,8 @@ class MessageDispatcherService(
     /**
      * Queues a message in kafka to be consumed by worker dispatchers
      */
-    fun enqueueMessage() {
-        kafkaTemplate.send(
-            "internal-message-queue", NotificationTask(
-                channel = Template.AlertType.EMAIL,
-                message = NotificationMessage(
-                    recipients = Recipients(
-                        to = listOf("")
-                    ),
-                    messageBody = "Hello World"
-                )
-            )
-        )
+    fun enqueueMessage(task: NotificationTask) {
+        kafkaTemplate.send("internal-message-queue", task)
     }
 
     /**

--- a/messaging-service/src/main/kotlin/com/forge/messageservice/services/TemplateVersionService.kt
+++ b/messaging-service/src/main/kotlin/com/forge/messageservice/services/TemplateVersionService.kt
@@ -48,7 +48,7 @@ class TemplateVersionService(
     }
 
     @Transactional(readOnly = true)
-    private fun findTemplateVersionByTemplateIdAndStatus(
+    fun findTemplateVersionByTemplateIdAndStatus(
         templateVersionId: Long,
         status: TemplateStatus
     ): TemplateVersion? {
@@ -64,7 +64,6 @@ class TemplateVersionService(
         val newTemplateVersion = TemplateVersion().apply {
             templateId = templateVersionInput.templateId
             status = DRAFT
-            templateHash = 0
             settings = getTemplateSetting(template)
         }
 
@@ -99,7 +98,6 @@ class TemplateVersionService(
                 templateVersionRepository.findCurrentVersionNumberByTemplateId(newTemplateVersion.templateId!!) + 1
             status = DRAFT
         }
-        newTemplateVersion.templateHash = newTemplateVersion.templateHash()
 
         val savedTemplateVersion = saveTemplateVersion(newTemplateVersion)
 
@@ -112,7 +110,6 @@ class TemplateVersionService(
     }
 
     private fun saveTemplateVersion(templateVersion: TemplateVersion): TemplateVersion {
-//        ensureTemplateHashDoesNotExist(templateVersion)
         return templateVersionRepository.save(templateVersion)
     }
 
@@ -127,7 +124,6 @@ class TemplateVersionService(
             version = templateVersionRepository.findCurrentVersionNumberByTemplateId(templateVersion.templateId!!) + 1
             status = templateVersionInput.status
         }
-        templateVersion.templateHash = templateVersion.templateHash()
 
         val savedTemplateVersion = saveTemplateVersion(templateVersion)
 

--- a/messaging-service/src/main/kotlin/com/forge/messageservice/services/aspects/EmailReviewAspect.kt
+++ b/messaging-service/src/main/kotlin/com/forge/messageservice/services/aspects/EmailReviewAspect.kt
@@ -35,7 +35,7 @@ class EmailReviewAspect(
         val message = joinPoint.args[0] as Message
         logger.info("(START) Pre Processing Actions for ${message.id}")
 
-        val templateVersion = templateVersionService.getTemplateVersionById(message.templateVersionId!!)
+        val templateVersion = templateVersionService.getTemplateVersion(message.templateVersionId!!)
         val templatePlugins = templatePluginService.getTemplatePluginsByTemplateVersionId(templateVersion.id!!)
 
         templatePlugins.map { templatePlugin ->
@@ -60,7 +60,7 @@ class EmailReviewAspect(
         val message = retVal as Message
         logger.info("(START) Post Processing Actions for ${message.id}")
 
-        val templateVersion = templateVersionService.getTemplateVersionById(message.templateVersionId!!)
+        val templateVersion = templateVersionService.getTemplateVersion(message.templateVersionId!!)
         val templatePlugins = templatePluginService.getTemplatePluginsByTemplateVersionId(templateVersion.id!!)
 
         templatePlugins.map { templatePlugin ->
@@ -85,7 +85,7 @@ class EmailReviewAspect(
         return MessageDetails(
             message.id!!,
             templateVersion.template!!.name!!,
-            templateVersion.templateHash!!,
+            templateVersion.templateDigest!!,
             message.appCode!!,
             templatingEngine.parseTemplate(templateVersion.body, messageContent),
             message.messageType,

--- a/messaging-service/src/main/kotlin/com/forge/messageservice/services/aspects/EmailReviewAspect.kt
+++ b/messaging-service/src/main/kotlin/com/forge/messageservice/services/aspects/EmailReviewAspect.kt
@@ -1,13 +1,10 @@
 package com.forge.messageservice.services.aspects
 
-import com.alphamail.plugin.api.AlphamailPlugin
 import com.alphamail.plugin.api.MessageDetails
-import com.alphamail.plugin.api.PluginConfiguration
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.forge.messageservice.common.engines.TemplatingEngine
 import com.forge.messageservice.entities.Message
-import com.forge.messageservice.entities.TemplatePlugin
 import com.forge.messageservice.entities.TemplateVersion
 import com.forge.messageservice.services.PluginService
 import com.forge.messageservice.services.TemplatePluginService
@@ -44,7 +41,7 @@ class EmailReviewAspect(
         templatePlugins.map { templatePlugin ->
             val plugin = pluginService.loadPlugin(templatePlugin.plugin!!, templatePlugin.configuration!!)
 
-            if (plugin.runsBefore()){
+            if (plugin.runsBefore()) {
                 try {
                     logger.info("Processing ${plugin.javaClass}")
                     plugin.execute(convertToMessageDetails(message, templateVersion))

--- a/messaging-service/src/main/resources/graphql/types/template.graphqls
+++ b/messaging-service/src/main/resources/graphql/types/template.graphqls
@@ -61,11 +61,11 @@ type TemplateVersion {
   """
   name: String
   """
-  Hash of the template version
+  Digest of the template version
   Ensuring that each template version is different
-  Hashing -> TemplateId, body, settings, status
+  Digest of -> body, settings
   """
-  templateHash: String
+  templateDigest: String
   """
   Template body
   EMAILS -> HTML format

--- a/messaging-service/src/test/kotlin/com/forge/messageservice/entities/TemplateVersionTest.kt
+++ b/messaging-service/src/test/kotlin/com/forge/messageservice/entities/TemplateVersionTest.kt
@@ -1,0 +1,18 @@
+package com.forge.messageservice.entities
+
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+internal class TemplateVersionTest {
+
+    @Test
+    fun itGeneratesSha256HashOfTheSettingsAndMessageBody() {
+        val templateVersion = TemplateVersion().apply {
+            settings = ""
+            body = ""
+        }
+
+        Assertions.assertNotNull(templateVersion.templateHash)
+    }
+
+}

--- a/messaging-service/src/test/kotlin/com/forge/messageservice/entities/TemplateVersionTest.kt
+++ b/messaging-service/src/test/kotlin/com/forge/messageservice/entities/TemplateVersionTest.kt
@@ -8,11 +8,11 @@ internal class TemplateVersionTest {
     @Test
     fun itGeneratesSha256HashOfTheSettingsAndMessageBody() {
         val templateVersion = TemplateVersion().apply {
-            settings = ""
-            body = ""
+            settings = "{}"
+            body = "{}"
         }
 
-        Assertions.assertNotNull(templateVersion.templateHash)
+        Assertions.assertNotNull(templateVersion.templateDigest)
     }
 
 }

--- a/messaging-service/src/test/kotlin/com/forge/messageservice/services/TemplateVersionServiceTest.kt
+++ b/messaging-service/src/test/kotlin/com/forge/messageservice/services/TemplateVersionServiceTest.kt
@@ -70,7 +70,6 @@ class TemplateVersionServiceTest {
                     "\"subject\": \"Bill Alert for the month of {{ month }} {{ year }}\", " +
                     "\"sender\": [\"{{ app.emails.defaultSender }}\"], " +
                     " \"format\": \"html | rich text\" }"
-            templateHash = 1234567
             body = "Hi, Bill Alert for the month of {{ month }} {{ year }}"
             version = 1L
             status = PUBLISHED
@@ -88,7 +87,6 @@ class TemplateVersionServiceTest {
                     "\"subject\": \"Bill Alert for the month of {{ month }} {{ year }}\", " +
                     "\"sender\": [\"{{ app.emails.defaultSender }}\"], " +
                     " \"format\": \"html | rich text\" }"
-            templateHash = 2345678
             body = "Hi, Bill Alert for the month of {{ month }} {{ year }}"
             version = 0L
             status = DRAFT
@@ -106,7 +104,6 @@ class TemplateVersionServiceTest {
                     "\"subject\": \"Bill Alert for the month of {{ month }} {{ year }}\", " +
                     "\"sender\": [\"{{ app.emails.defaultSender }}\"], " +
                     " \"format\": \"html | rich text\" }"
-            templateHash = 2345678
             body = "Hi, Bill Alert for the month of {{ month }} {{ year }}"
             version = 0L
             status = DRAFT
@@ -205,7 +202,6 @@ class TemplateVersionServiceTest {
         val mockTemplateVersion = TemplateVersion().apply {
             templateId = templateIdExist
             status = DRAFT
-            templateHash = 0
         }
 
         every {
@@ -222,7 +218,7 @@ class TemplateVersionServiceTest {
 
         assert(templateVersion.id == templateIdExist)
         assert(templateVersion.status == DRAFT)
-        assert(templateVersion.templateHash == 0)
+
     }
 
     @Test
@@ -265,7 +261,6 @@ class TemplateVersionServiceTest {
             version = 3L
             status = PUBLISHED
         }
-        mockPublishedTemplateVersion.templateHash = mockPublishedTemplateVersion.templateHash()
 
         every { templateVersionRepository.findById(templateVersionId) } returns Optional.of(mockTemplateVersionOneDraft())
         every { templateVersionRepository.save(any()) } returns mockPublishedTemplateVersion
@@ -314,57 +309,5 @@ class TemplateVersionServiceTest {
             )
         }
     }
-
-
-    //TODO: Template Hash giving some issue now. Will fix when there's time.
-//    @Test
-//    fun itShouldThrowsAnExceptionWhenUpdatingTemplateVersionWhereBodyAndSettingAlreadyExist() {
-//        val templateVersionId = 1L
-//        val templateVersionName = "New Template Version Name"
-//        val templateVersionSettings = "{ \"to\": [\"receipient@company.com\"] }"
-//        val templateVersionBody = "Hi {{ username }}, this email is to inform you about your bill alert."
-//
-//        val updatePublishTemplateVersionInput = UpdateTemplateVersionInput(
-//            templateVersionId,
-//            templateVersionName,
-//            templateVersionSettings,
-//            templateVersionBody,
-//            PUBLISHED,
-//            mockPluginsInput()
-//        )
-//
-//        val mockPublishedTemplateVersion = TemplateVersion().apply {
-//            id = templateVersionId
-//            name = templateVersionName
-//            settings = templateVersionSettings
-//            body = templateVersionBody
-//            version = 3L
-//            status = PUBLISHED
-//        }
-//        mockPublishedTemplateVersion.templateHash = mockPublishedTemplateVersion.templateHash()
-//
-//        every { templateVersionRepository.findById(templateVersionId) } returns Optional.of(mockTemplateVersionOneDraft())
-//        every { templateVersionRepository.save(any()) } returns mockPublishedTemplateVersion
-//        every { templateVersionRepository.findCurrentVersionNumberByTemplateId(1L) } returns 3L
-//        every {
-//            templatePluginService.createTemplatePlugins(
-//                templateVersionId,
-//                mockPluginsInput()
-//            )
-//        } returns mockTemplatePlugins()
-//
-//        every {
-//            templateVersionRepository.existsByTemplateIdAndTemplateHash(
-//                1L,
-//                mockPublishedTemplateVersion.templateHash!!
-//            )
-//        } returns true
-//
-//        assertThrows<TemplateHashExistedException> {
-//            templateVersionService.updateTemplateVersion(
-//                updatePublishTemplateVersionInput
-//            )
-//        }
-//    }
 
 }

--- a/messaging-service/src/test/kotlin/com/forge/messageservice/services/TemplateVersionServiceTest.kt
+++ b/messaging-service/src/test/kotlin/com/forge/messageservice/services/TemplateVersionServiceTest.kt
@@ -144,7 +144,7 @@ class TemplateVersionServiceTest {
 
         every { templateVersionRepository.findAllByTemplateId(templateId) } returns mockListOfTemplateVersions()
 
-        val templateVersions = templateVersionService.getAllTemplateVersionsByTemplateId(templateId)
+        val templateVersions = templateVersionService.getAllTemplateVersionsOf(templateId)
 
         assert(templateVersions.isNotEmpty())
         templateVersions.forEach { templateVersion ->
@@ -162,7 +162,7 @@ class TemplateVersionServiceTest {
         every { templateVersionRepository.findAllByTemplateId(templateIdThatDoesNotExist) } returns listOf()
 
         val blankTemplateVersions =
-            templateVersionService.getAllTemplateVersionsByTemplateId(templateIdThatDoesNotExist)
+            templateVersionService.getAllTemplateVersionsOf(templateIdThatDoesNotExist)
 
         assert(blankTemplateVersions.isNullOrEmpty())
     }
@@ -175,7 +175,7 @@ class TemplateVersionServiceTest {
             mockTemplateVersionOnePublished()
         )
 
-        val templateVersion = templateVersionService.getTemplateVersionById(templateVersionIdExist)
+        val templateVersion = templateVersionService.getTemplateVersion(templateVersionIdExist)
 
         assert(templateVersion.id == templateVersionIdExist)
     }
@@ -187,7 +187,7 @@ class TemplateVersionServiceTest {
         every { templateVersionRepository.findById(templateVersionIdDoesNotExist) } returns Optional.empty()
 
         assertThrows<TemplateVersionDoesNotExistException> {
-            templateVersionService.getTemplateVersionById(
+            templateVersionService.getTemplateVersion(
                 templateVersionIdDoesNotExist
             )
         }
@@ -273,9 +273,9 @@ class TemplateVersionServiceTest {
         } returns mockTemplatePlugins()
 
         every {
-            templateVersionRepository.existsByTemplateIdAndTemplateHash(
+            templateVersionRepository.existsByTemplateIdAndTemplateDigest(
                 1L,
-                mockPublishedTemplateVersion.templateHash!!
+                mockPublishedTemplateVersion.templateDigest!!
             )
         } returns false
 

--- a/messaging-service/src/test/resources/features/10_create_template.feature
+++ b/messaging-service/src/test/resources/features/10_create_template.feature
@@ -1,7 +1,6 @@
 #lang: en
 Feature: 10 Create Template
 
-  @ignore
   Scenario: User creates a new template
     Given a user has logged in
     | username | ntfusr1 |
@@ -15,6 +14,22 @@ Feature: 10 Create Template
           "name": "new template 1",
           "alertType": "EMAIL",
           "appCode": "FABK"
+        }
+      }
+    }
+    """
+    Then we should receive a response code of 200
+
+    Given a user has logged in
+      | username | ntfusr1 |
+      | password | secret  |
+    When we call GraphQL with requestBody
+    """
+    {
+      "query": "mutation createTemplateVersion($input: CreateTemplateVersionInput!) { createTemplateVersion(input: $input) { id name templateHash body status } }",
+      "variables": {
+        "input": {
+          "templateId": "1"
         }
       }
     }

--- a/shared/src/main/kotlin/com/alphamail/plugin/api/MessageDetails.kt
+++ b/shared/src/main/kotlin/com/alphamail/plugin/api/MessageDetails.kt
@@ -3,7 +3,7 @@ package com.alphamail.plugin.api
 class MessageDetails(
     val id: Long,
     val templateName: String,
-    val templateVersionHash: Int,
+    val templateVersionHash: String,
     val appCode: String,
     val body: String,
     val messageType: MessageType,


### PR DESCRIPTION
- Prevent templateHash from being set externally (outside of TemplateVersion)
- Use DigestUtils.sha256Hex instead of Objects.hash
- Changed templateHash from Int to String